### PR TITLE
Stopped snake from moving in opposite direction

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -43,7 +43,7 @@ impl Game {
             _ => None,
         };
         if let Some(new_dir) = dir {
-            if new_dir.opposite() != self.snake.dir {
+            if -new_dir != self.snake.dir {
                 self.snake.dir = new_dir;
             }
         }

--- a/src/game.rs
+++ b/src/game.rs
@@ -32,6 +32,8 @@ impl Game {
         self.food.x = random(self.width);
         self.food.y = random(self.height);
     }
+    /// Takes a pressed key (one of the arrow keys) and turns the snake around.
+    /// The snake is not allowed to go in the opposite direction as it would bite itself.
     pub fn key_pressed(&mut self, key: Key) {
         let dir = match key {
             Key::Up => Some(Direction::Up),
@@ -41,7 +43,9 @@ impl Game {
             _ => None,
         };
         if let Some(new_dir) = dir {
-            self.snake.dir = new_dir;
+            if new_dir.opposite() != self.snake.dir {
+                self.snake.dir = new_dir;
+            }
         }
     }
     pub fn update(&mut self, delta_time: f64) {

--- a/src/snake.rs
+++ b/src/snake.rs
@@ -3,8 +3,9 @@ use piston_window::{Context, G2d};
 use std::collections::LinkedList;
 
 use crate::draw::draw_block;
+use std::ops::Neg;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum Direction {
     Up,
     Down,
@@ -12,8 +13,10 @@ pub enum Direction {
     Right,
 }
 
-impl Direction {
-    pub fn opposite(&self) -> Direction {
+impl Neg for Direction {
+    type Output = Self;
+
+    fn neg(self) -> Direction {
         use Direction::*;
         match self {
             Up => Down,

--- a/src/snake.rs
+++ b/src/snake.rs
@@ -4,11 +4,24 @@ use std::collections::LinkedList;
 
 use crate::draw::draw_block;
 
+#[derive(PartialEq)]
 pub enum Direction {
     Up,
     Down,
     Left,
     Right,
+}
+
+impl Direction {
+    pub fn opposite(&self) -> Direction {
+        use Direction::*;
+        match self {
+            Up => Down,
+            Down => Up,
+            Left => Right,
+            Right => Left,
+        }
+    }
 }
 
 pub struct Block {


### PR DESCRIPTION
Since the snake would immediatly bite itself, I prevented the player from changing direction in the opposite direction.